### PR TITLE
feat(hid): Implement hid_get_input_report and Microsoft device filtering

### DIFF
--- a/src-tauri/src/hid.rs
+++ b/src-tauri/src/hid.rs
@@ -926,6 +926,30 @@ pub async fn hid_send_feature_report(
 }
 
 #[tauri::command]
+pub async fn hid_get_input_report(
+    registry: tauri::State<'_, HidRegistry>,
+    vendor_id: u16,
+    product_id: u16,
+    report_id: u8,
+    length: usize,
+) -> Result<Vec<u8>, String> {
+    applog!("[hid] hid_get_input_report {vendor_id:04x}:{product_id:04x} reportId=0x{report_id:02x} length={length}");
+    let result = with_open_group(&registry, vendor_id, product_id, |splits, routes| {
+        let mut result: Option<Vec<u8>> = None;
+        let outcome = try_each(splits, routes, report_id, |device| {
+            let mut buffer = vec![0u8; length + 1];
+            buffer[0] = report_id;
+            let read = device.get_input_report(&mut buffer)?;
+            let data_end = read.min(buffer.len());
+            result = Some(buffer[1..data_end].to_vec());
+            Ok(())
+        });
+        outcome.and(result.ok_or_else(|| "no split returned data".to_string()))
+    });
+    applog!("[hid] hid_get_input_report done: {result:?}");
+    result
+}
+#[tauri::command]
 pub async fn hid_get_feature_report(
     registry: tauri::State<'_, HidRegistry>,
     vendor_id: u16,

--- a/src-tauri/src/hid.rs
+++ b/src-tauri/src/hid.rs
@@ -499,12 +499,26 @@ pub fn hid_open(
         // below, so Windows genuinely needs it mutable even though macOS
         // can't see why.
         #[cfg_attr(not(target_os = "windows"), allow(unused_mut))]
-        let mut paths: Vec<String> = api
+        let mut infos: Vec<_> = api
             .device_list()
             .filter(|info| {
                 info.vendor_id() == vendor_id
                     && info.product_id() == product_id
             })
+            .collect();
+        // Prioritize Vendor-Specific collections (>= 0xFF00) and Consumer Control (0x000C).
+        // On Linux, hidapi can open the standard mouse pointer collection (0x0001),
+        // which often acts as a black hole: it successfully accepts feature reports
+        // but drops them or returns zeroes. By trying vendor collections first,
+        // `try_each` routes the configuration protocol to the correct interface.
+        infos.sort_by_key(|info| match info.usage_page() {
+            p if p >= 0xFF00 => 0,
+            0x000C => 1,
+            _ => 2,
+        });
+        #[cfg_attr(not(target_os = "windows"), allow(unused_mut))]
+        let mut paths: Vec<String> = infos
+            .into_iter()
             .map(|info| {
                 let p = info.path().to_string_lossy().into_owned();
                 applog!(
@@ -515,6 +529,7 @@ pub fn hid_open(
                 p
             })
             .collect();
+
 
         // On Windows, merge in any extra sub-collection paths that
         // hidapi missed but SetupDi enumerated.

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -92,6 +92,7 @@ pub fn run() {
             hid::hid_send_report,
             hid::hid_send_feature_report,
             hid::hid_get_feature_report,
+            hid::hid_get_input_report,
             discord_rpc::enable,
             discord_rpc::disable,
             discord_rpc::update_activity,

--- a/src/native-hid/brands.ts
+++ b/src/native-hid/brands.ts
@@ -30,6 +30,8 @@ import { KeychronNapeHidClient } from "@openmouse/protocol/drivers/keychron/nape
 import { LamzuHidClient } from "@openmouse/protocol/drivers/lamzu/hid";
 import { LogitechHidppClient } from "@openmouse/protocol/drivers/logitech/hidpp";
 import { ModdoHidClient } from "@openmouse/protocol/drivers/moddo/hid";
+import { MicrosoftHidClient } from "@openmouse/protocol/drivers/microsoft/hid";
+import { MICROSOFT_PRODUCTS } from "@openmouse/protocol/microsoft";
 import { NinjutsoHidClient } from "@openmouse/protocol/drivers/ninjutso/hid";
 import { OrbitalHidClient } from "@openmouse/protocol/drivers/orbital/hid";
 import { PulsarHidClient } from "@openmouse/protocol/drivers/pulsar/pulsar-hid";
@@ -74,6 +76,7 @@ export interface DriverCandidate {
    * aren't exported.
    */
   excludeProductIds?: number[];
+  includeProductIds?: number[];
 }
 
 export interface BrandEntry {
@@ -91,10 +94,12 @@ const client = (
   name: string,
   Client: new (device: HIDDevice) => unknown,
   excludeProductIds?: number[],
+  includeProductIds?: number[],
 ): DriverCandidate => ({
   name,
   Client: Client as new (device: HIDDevice) => SupportedClient,
   excludeProductIds,
+  includeProductIds,
 });
 
 export const BRAND_DRIVERS: BrandEntry[] = [
@@ -135,6 +140,7 @@ export const BRAND_DRIVERS: BrandEntry[] = [
   // that matches the product id.
   { brand: "CRDRAKO", vendorIds: [0x373e], candidates: [client("LamzuHidClient", LamzuHidClient)] },
   { brand: "moddoMOUSE", vendorIds: [0x2fe3], candidates: [client("ModdoHidClient", ModdoHidClient)] },
+  { brand: "Microsoft", vendorIds: [0x045e], candidates: [client("MicrosoftHidClient", MicrosoftHidClient, undefined, [...MICROSOFT_PRODUCTS])] },
   // NINJUTSO_VENDOR_ID (current) and NINJUTSO_LEGACY_VENDOR_ID (shared with
   // Orbital) — see mouse-protocol/src/ninjutso/index.ts.
   { brand: "Ninjutso", vendorIds: [0x093a, 0x1915], candidates: [client("NinjutsoHidClient", NinjutsoHidClient)] },
@@ -189,5 +195,6 @@ export function candidatesForVendorId(vendorId: number, productId: number): Bran
   return BRAND_DRIVERS
     .filter((entry) => entry.vendorIds.includes(vendorId))
     .flatMap((entry) => entry.candidates.map((candidate) => ({ ...candidate, brand: entry.brand })))
-    .filter((candidate) => !candidate.excludeProductIds?.includes(productId));
+    .filter((candidate) => !candidate.excludeProductIds?.includes(productId))
+    .filter((candidate) => candidate.includeProductIds === undefined || candidate.includeProductIds.includes(productId));
 }

--- a/src/native-hid/tauri-hid-device.ts
+++ b/src/native-hid/tauri-hid-device.ts
@@ -129,6 +129,25 @@ export class TauriHidDevice implements HIDDevice {
     return new DataView(Uint8Array.from(bytes).buffer);
   }
 
+  async receiveInputReport(reportId: number): Promise<DataView> {
+    const isWindows = navigator.userAgent.includes("Win") || navigator.platform.includes("Win");
+    if (!isWindows) {
+      // The Intellimouse firmware is quirky: it responds to GET_REPORT(Feature) 
+      // but not GET_REPORT(Input) over the control pipe.
+      // On Windows, get_input_report works because Windows caches the interrupt response.
+      // On Linux/macOS, get_input_report sends a real GET_REPORT(Input) and returns all 0s.
+      // Fortunately, Linux/macOS don't block get_feature_report, so we just use that.
+      return this.receiveFeatureReport(reportId);
+    }
+    const bytes = await invoke<number[]>("hid_get_input_report", {
+      vendorId: this.vendorId,
+      productId: this.productId,
+      reportId,
+      length: 90,
+    });
+    return new DataView(Uint8Array.from(bytes).buffer);
+  }
+
   addEventListener(type: "inputreport", listener: (event: HIDInputReportEvent) => void): void {
     if (type !== "inputreport") return;
     this.listeners.add(listener);


### PR DESCRIPTION
This PR introduces a necessary loophole to bypass Windows OS read blocks for specific mice, hardens interface selection, and cleans up the Microsoft device registry.

**Key Changes:**
* **Implement `hid_get_input_report`:** Windows strictly blocks user-mode applications from reading Input Reports via `ReadFile` on standard System Mouse collections to prevent keyloggers. This adds a custom `hid_get_input_report` command in the Rust backend wired to `receiveInputReport` in `TauriHidDevice`. This issues a raw USB Control Transfer (Endpoint 0) instead of reading the interrupt pipeline, successfully bypassing the OS block.
* **Prioritize Interfaces in `hid.rs`:** `try_each` now sorts enumerated `hidapi` interfaces to prioritize Vendor-Specific (`>= 0xFF00`) and Consumer Control (`0x000C`) collections over standard pointer collections. This prevents `try_each` from permanently locking onto "black hole" pointer interfaces that accept commands but swallow the data.
* **Add Microsoft Support with `includeProductIds`:** Adds the Microsoft brand to the device scanner, but introduces a new `includeProductIds` filter in `brands.ts`. This ensures the Desktop app only claims verified IntelliMice, preventing it from incorrectly grabbing every built-in Microsoft keyboard, touchpad, or Surface generic input on the user's machine.

Requires this PR in `mouse-protocol`: https://github.com/OpenMouse-Project/mouse-protocol/pull/98